### PR TITLE
Duplicate hibernate-validator dependency entry in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,11 +118,6 @@
         </dependency>
         
         <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-validator</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.vaadin</groupId>
             <artifactId>viritin</artifactId>
             <version>1.37</version>

--- a/src/main/java/org/vaadin/springportlet/LibraryPortletUserService.java
+++ b/src/main/java/org/vaadin/springportlet/LibraryPortletUserService.java
@@ -24,7 +24,7 @@ import com.vaadin.server.VaadinPortlet.VaadinLiferayRequest;
 import com.vaadin.spring.annotation.UIScope;
 
 /**
- * A service class that accesses JPA entities via Sprin Data Repository and
+ * A service class that accesses JPA entities via Spring Data Repository and
  * combines that data with the users specific details provided by Liferay
  * services. Also used to hide some Liferay specific code from the UI layer.
  */

--- a/src/main/webapp/VAADIN/themes/mytheme/mytheme.scss
+++ b/src/main/webapp/VAADIN/themes/mytheme/mytheme.scss
@@ -35,4 +35,7 @@ $v-focus-color: #50a2f5;
   	height: 30px !important;
   }
   
+  .v-formlayout .v-errorindicator {
+    height: 30px;
+  }
 }


### PR DESCRIPTION
Eliminating some warning when building, because of duplicate hibernate-validator dependency entry in pom
